### PR TITLE
Avoid crash when open app that is not installed

### DIFF
--- a/app/src/main/java/com/qrist/quicker/camera/CameraFragment.kt
+++ b/app/src/main/java/com/qrist/quicker/camera/CameraFragment.kt
@@ -2,10 +2,7 @@ package com.qrist.quicker.camera
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
-import android.content.Intent
+import android.content.*
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
@@ -34,8 +31,24 @@ class CameraFragment : Fragment() {
     private fun displayURLDialog(url: String) {
         val uri = Uri.parse(url)
         val intent = Intent(Intent.ACTION_VIEW, uri)
+        try {
+            startActivity(intent)
+        } catch (exception: ActivityNotFoundException) {
+            val appName = url.split("://")[0]
+            MaterialDialog(context!!).show {
+                title(R.string.code_scan_failed_title)
+                message(text = getString(R.string.code_scan_failed, appName, appName))
+                positiveButton(R.string.zxing_button_ok) {
+                    isDialogSeen = false
+                    previousValue = null
+                }
+                setOnCancelListener {
+                    isDialogSeen = false
+                    previousValue = null
+                }
+            }
+        }
         isDialogSeen = true
-        startActivity(intent)
     }
 
     private fun displayRawDialog(value: String) {

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -34,4 +34,6 @@
     <string name="hint_generate_from_url">https://…</string>
     <string name="generate_from_url">URLからQRコードを生成する</string>
     <string name="generate">生成</string>
+    <string name="code_scan_failed_title">リンクが開けません</string>
+    <string name="code_scan_failed">%1$sがインストールされていない為、表示できません。%2$sをインストールしてください。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
     <string name="hint_generate_from_url">https://…</string>
     <string name="generate_from_url">Generate a QR Code from URL</string>
     <string name="generate">Generate</string>
+    <string name="code_scan_failed_title">Can not open the link.</string>
+    <string name="code_scan_failed">Can not open the link because %1$s is not installed. Please install %2$s.</string>
 </resources>


### PR DESCRIPTION
# Description
QRコードリータでインストールされていないアプリを開こうとすると落ちる問題を回避するPRです．

# Implementation
もともとrelease/1.1.5ブランチにてAndroidXのない状態で直した修正をそのままDevelopブランチに適用しました